### PR TITLE
fix: `atom:link` should have `rel="self"`

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -24,7 +24,14 @@ function getText(element: Element, tagName: string): string {
 export function createPodcast(document: Document, source: string | URL | number): Podcast {
   const documentElement = removeItemsFromDocument(document).documentElement;
   const imageElem = documentElement.getElementsByTagName("image")[0];
-  let feedUrl = documentElement.getElementsByTagName("atom:link")[0]?.getAttribute("href") ?? "";
+  let feedUrl = "";
+  const atomLinks = documentElement.getElementsByTagName("atom:link") ?? [];
+  for (const atomLink of Array.from(atomLinks)) {
+    if (atomLink.getAttribute("rel") === "self") {
+      feedUrl = atomLink.getAttribute("href") ?? "";
+      break;
+    }
+  }
   if (feedUrl === "" && source instanceof URL) {
     feedUrl = source.toString();
   }


### PR DESCRIPTION
Closes: #8 

**Description**

When retrieving the `atom:link` from an RSS feed, the current implementation fails to accurately identify the correct link for the feed URL. The expected behavior is to obtain the `atom:link` element with the attribute `rel="self"`, representing the feed's own URL.